### PR TITLE
Adding support for Google Apps domain aliases.

### DIFF
--- a/gapslib.py
+++ b/gapslib.py
@@ -6,6 +6,7 @@ import textwrap
 import hashlib
 import syslog
 import gdata.apps.multidomain.client;
+import re
 
 from samba.credentials import Credentials
 from samba.auth import system_session
@@ -20,6 +21,8 @@ gaPassword = "yourpassword"
 sambaPrivate = "/usr/local/samba/private"
 sambaPath = "DC=YOURDOMAIN,DC=COM"
 adBase = "ou=Domain Users,dc=yourdomain,dc=com"
+### Set this option to True if using domain aliases ###
+replaceDomain = False
 
 ## Open connection to Syslog ##
 syslog.openlog(logoption=syslog.LOG_PID, facility=syslog.LOG_LOCAL3)
@@ -40,6 +43,9 @@ def print_entry(dn, user, mail, pwd):
 
 def update_password(mail, pwd):
     password = hashlib.sha1(pwd).hexdigest()
+
+    if replaceDomain:
+      mail = re.search("([\w.-]+)@", mail).group() + gaDomain
 
     if passwords.has_key(mail):
         if passwords[mail] == password:


### PR DESCRIPTION
With this change, samba4-gaps will support Google Apps domain aliases. For example, if a company owns both "longerdomain.com" (the primary domain) and "shortdomain.com" (the alias domain) and the users have been given the option of either domain for their email suffix, samba4-gaps will not properly synchronize passwords for those users who have "shortdomain.com" in their AD "mail" entry. 

This patch gives the option to replace "shortdomain.com" with whatever "gaDomain" is set to (in this example, it would be "longerdomain.com"). The option is set via the "replaceDomain" boolean. 

Thank you for this project! It has saved me from installing a Windows server.
