### PR TITLE
No Need store-plaintext

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,6 @@ Google Apps Password Sync for Samba4
 Reads from your Samba4 AD and updates passwords in Google Apps in SHA1 format.
 Note that this solution requires you to enable plaintext passwords:
 
-samba-tool domain passwordsettings set --store-plaintext=on
-
-Also you will have to use "Store passwords using reversible encryption" for each users. This can be enabled with MS Active Directory snap in tool from Windows.
-
 Python Dependencies
 ===========
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Google Apps Password Sync for Samba4
 
 
 Reads from your Samba4 AD and updates passwords in Google Apps in SHA1 format.
-Note that this solution requires you to enable plaintext passwords:
+Note that this solution requires you to enable "password hash userPassword schemes = CryptSHA256" in smb.conf
 
 Python Dependencies
 ===========

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 Google Apps Password Sync for Samba4
 ===========
 
-
 Reads from your Samba4 AD and updates passwords in Google Apps 
-Note that this solution requires you to enable "password hash userPassword schemes = CryptSHA256" in smb.conf if you use CryptSHA256 or CryptSHA512
+Note that this solution requires you to enable "password hash userPassword schemes = CryptSHA256 CryptSHA512" in smb.conf
 
 Python Dependencies
 ===========

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ Google Apps Password Sync for Samba4
 ===========
 
 
-Reads from your Samba4 AD and updates passwords in Google Apps in SHA1 format.
-Note that this solution requires you to enable "password hash userPassword schemes = CryptSHA256" in smb.conf
+Reads from your Samba4 AD and updates passwords in Google Apps 
+Note that this solution requires you to enable "password hash userPassword schemes = CryptSHA256" in smb.conf if you use CryptSHA256 or CryptSHA512
 
 Python Dependencies
 ===========

--- a/gaps.conf
+++ b/gaps.conf
@@ -2,6 +2,11 @@
 domain = yourdomain.com
 replace_domain = false
 path_password_file=/root/dict_mail_password.json
+#attr_password=virtualCryptSHA256
+#attr_password=virtualCryptSHA512
+
+#NTLM
+attr_password=unicodePwd
 
 [google]
 admin_email = adminuser@yourdomain.com
@@ -11,4 +16,3 @@ service_json = /etc/gaps/service.json
 private = /usr/local/samba/private
 path = DC=YOURDOMAIN,DC=COM
 base = ou=Domain Users,dc=yourdomain,dc=com
-

--- a/gaps.conf
+++ b/gaps.conf
@@ -1,6 +1,7 @@
 [common]
 domain = yourdomain.com
 replace_domain = false
+path_password_file=/root/dict_mail_password.json
 
 [google]
 admin_email = adminuser@yourdomain.com

--- a/gaps.conf
+++ b/gaps.conf
@@ -2,11 +2,8 @@
 domain = yourdomain.com
 replace_domain = false
 path_password_file=/root/dict_mail_password.json
-#attr_password=virtualCryptSHA256
+attr_password=virtualCryptSHA256
 #attr_password=virtualCryptSHA512
-
-#NTLM
-attr_password=unicodePwd
 
 [google]
 admin_email = adminuser@yourdomain.com

--- a/gaps.conf
+++ b/gaps.conf
@@ -1,7 +1,7 @@
 [common]
 domain = yourdomain.com
 replace_domain = false
-path_password_file=/root/dict_mail_password.json
+path_password_file=/root/dict_mail_pwdlastset.json
 attr_password=virtualCryptSHA256
 #attr_password=virtualCryptSHA512
 

--- a/gaps.conf
+++ b/gaps.conf
@@ -1,7 +1,7 @@
 [common]
 domain = yourdomain.com
 replace_domain = false
-path_password_file=/root/dict_mail_pwdlastset.json
+path_pwdlastset_file=/root/dict_mail_pwdlastset.json
 attr_password=virtualCryptSHA256
 #attr_password=virtualCryptSHA512
 

--- a/gapslib.py
+++ b/gapslib.py
@@ -29,7 +29,7 @@ config.read('/etc/gaps/gaps.conf')
 ## Open connection to Syslog ##
 syslog.openlog(logoption=syslog.LOG_PID, facility=syslog.LOG_LOCAL3)
 
-filename = config.get('common', 'path_password_file')
+filename = config.get('common', 'path_pwdlastset_file')
 dict_mail_pwdlastset={}
 if os.path.isfile(filename):
     dict_mail_pwdlastset = json.loads(open(filename,'r').read())
@@ -109,12 +109,12 @@ def run():
 
         if str(pwdlastset) != dict_mail_pwdlastset.get(mail,''):
 
-            # Update if password different in dict mail password
+            # Update if password different in dict mail pwdlastset
             password = testpawd.get_account_attributes(samdb_loc,None,param_samba['basedn'],filter="(sAMAccountName=%s)" % (str(user["sAMAccountName"])),scope=ldb.SCOPE_SUBTREE,attrs=[passwordattr],decrypt=True)
             password = str(password[passwordattr])
             update_password(mail, password, pwdlastset)
 
-    #delete user found in dict mail password but not found in samba
+    #delete user found in dict mail pwdlastset but not found in samba
     listdelete = []
     for user in dict_mail_pwdlastset :
         if not user in allmail:

--- a/gapslib.py
+++ b/gapslib.py
@@ -124,7 +124,8 @@ def run():
         del dict_mail_pwdlastset[user]
 
     #write new json dict mail password
-    open(filename,'w').write(json.dumps(dict_mail_pwdlastset))
+    if listdelete:
+        open(filename,'w').write(json.dumps(dict_mail_pwdlastset))
 
 
 

--- a/gapslib.py
+++ b/gapslib.py
@@ -123,9 +123,7 @@ def run():
         del dict_mail_password[user]
 
     #write new json dict mail password
-    with open(filename, "w") as fOut:
-        open(filename,'w').write(json.dumps(dict_mail_password))
-
+    open(filename,'w').write(json.dumps(dict_mail_password))
 
 
 

--- a/gapslib.py
+++ b/gapslib.py
@@ -111,6 +111,8 @@ def run():
 
             # Update if password different in dict mail pwdlastset
             password = testpawd.get_account_attributes(samdb_loc,None,param_samba['basedn'],filter="(sAMAccountName=%s)" % (str(user["sAMAccountName"])),scope=ldb.SCOPE_SUBTREE,attrs=[passwordattr],decrypt=True)
+            if not passwordattr in password:
+                continue
             password = str(password[passwordattr])
             update_password(mail, password, pwdlastset)
 

--- a/gapslib.py
+++ b/gapslib.py
@@ -99,7 +99,7 @@ def run():
         mail = str(user["mail"])
 
         #replace mail if replace_domain in config
-        if config.get('common', 'replace_domain'):
+        if config.getboolean('common', 'replace_domain'):
             mail = mail.split('@')[0] + '@' + config.get('common', 'domain')
 
         pwdlastset = user.get('pwdLastSet','')

--- a/gapslib.py
+++ b/gapslib.py
@@ -7,29 +7,33 @@ import hashlib
 import syslog
 import json
 import httplib2
-import re
+import ldb
+import os
 
 from apiclient import errors
 from apiclient.discovery import build
-from oauth2client.client import SignedJwtAssertionCredentials
 
-from samba.credentials import Credentials
 from samba.auth import system_session
-from samba.dcerpc import drsblobs
-from samba.ndr import ndr_unpack
+from samba.credentials import Credentials
+from samba.param import LoadParm
 from samba.samdb import SamDB
+from samba.netcmd.user import GetPasswordCommand
 
 from ConfigParser import SafeConfigParser
+from oauth2client.client import SignedJwtAssertionCredentials
 
 ## Get confgiruation
 config = SafeConfigParser()
 config.read('/etc/gaps/gaps.conf')
 
+
 ## Open connection to Syslog ##
 syslog.openlog(logoption=syslog.LOG_PID, facility=syslog.LOG_LOCAL3)
 
-## Cached SHA 1 Passwords ##
-passwords = {}
+filename = config.get('common', 'path_password_file')
+dict_mail_password={}
+if os.path.isfile(filename):
+    dict_mail_password = json.loads(open(filename,'r').read())
 
 ## Load Google Configuration ##
 with open( config.get('google', 'service_json')) as data_file:
@@ -49,23 +53,8 @@ def createDirectoryService(user_email):
 
   return build('admin', 'directory_v1', http=http)
 
-def esc(s):
-    return quopri.encodestring(s, quotetabs=True)
-
-def print_entry(dn, user, mail, pwd):
-    print '%s\t%s\t%s\t%s' % tuple([esc(p) for p in [dn, user, mail, pwd]])
 
 def update_password(mail, pwd):
-    pwd = pwd.encode('ascii', 'ignore')
-    password = hashlib.sha1(pwd).hexdigest()
-
-    if config.get('common', 'replace_domain'):
-      mail = re.search("([\w.-]+)@", mail).group() + config.get('common', 'domain')
-
-    if passwords.has_key(mail):
-        if passwords[mail] == password:
-            return 0
-
     # Create a new service object
     service = createDirectoryService(config.get('google', 'admin_email'))
 
@@ -75,34 +64,48 @@ def update_password(mail, pwd):
         syslog.syslog(syslog.LOG_WARNING, '[WARNING] Account %s not found' % mail)
         return 0
 
-    user['hashFunction'] = 'SHA-1'
+    #TODO VERIFICATION IF IS OK
+    user['hashFunction'] = 'SHA-2'
     user['password'] = password
 
     try:
         service.users().update(userKey = mail, body=user).execute()
         syslog.syslog(syslog.LOG_WARNING, '[NOTICE] Updated password for %s' % mail)
-        passwords[mail] = password
+        dict_mail_password[str(user["mail"])]=str(password[passwordattr])
+        open(filename,'w').write(json.dumps(dict_mail_password))
     except:
         syslog.syslog(syslog.LOG_WARNING, '[ERROR] Could not update password for %s ' % mail)
+    finally:
+        service = None
 
 def run():
-    sambaPrivate = config.get('samba', 'private')
-    sambaPath = config.get('samba', 'path')
-    adBase = config.get('samba', 'base')
 
+    param_samba = {
+    'basedn' : config.get('samba', 'path'),
+    'pathsamdb':'%s/sam.ldb' % config.get('samba', 'private'),
+    'adbase': config.get('samba', 'base')
+    }
+
+    # SAMDB
+    lp = LoadParm()
     creds = Credentials()
-    samdb = SamDB(url=(sambaPrivate + "/sam.ldb.d/" + sambaPath + ".ldb"), session_info=system_session(), credentials=creds.guess())
-    res = samdb.search(base=adBase, expression="(objectClass=user)", attrs=["supplementalCredentials", "sAMAccountName", "mail"])
+    creds.guess(lp)
+    samdb_loc = SamDB(url=param_samba['pathsamdb'], session_info=system_session(),credentials=creds, lp=lp)
+    filename ='dict_mail_password.json'
+    testpawd = GetPasswordCommand()
+    testpawd.lp = lp
 
-    for r in res:
-         if not "supplementalCredentials" in r:
-             sys.stderr.write("%s: no supplementalCredentials\n" % str(r["dn"]))
-             continue
-         scb = ndr_unpack(drsblobs.supplementalCredentialsBlob, str(r["supplementalCredentials"]))
-         for p in scb.sub.packages:
-             if p.name == "Primary:CLEARTEXT":
-                 update_password(str(r["mail"]), binascii.unhexlify(p.data).decode("utf16"))
+    passwordattr = 'virtualCryptSHA256'
+    for user in samdb_loc.search(base=param_samba['adbase'], expression="(&(objectClass=user)(mail=*))", attrs=["mail","sAMAccountName"]):
 
+        mail = str(user["mail"])
+        if config.get('common', 'replace_domain'):
+            mail = mail.split('@')[0] + '@' + config.get('common', 'domain')
+
+        password = testpawd.get_account_attributes(samdb_loc,None,param_samba['basedn'],filter="(sAMAccountName=%s)" % (str(user["sAMAccountName"])),scope=ldb.SCOPE_SUBTREE,attrs=[passwordattr],decrypt=True)
+        if passwordattr in password:
+            if str(password[passwordattr]) != dict_mail_password.get(mail,''):
+                update_password(mail, str(password[passwordattr]))
 
 
 


### PR DESCRIPTION
No need to activate "store-plaintext" in samba.
Make use the "userPassword schemes" available in the new version of samba

Backup pwdlastset to avoid returning all passwords when restarting Gaps